### PR TITLE
bugfix: tagname with multiple colon is missing

### DIFF
--- a/ec2.go
+++ b/ec2.go
@@ -113,7 +113,7 @@ func findTagAll(tags []*ec2.Tag) string {
 }
 
 func findTagValue(columnName string, tags []*ec2.Tag) string {
-	tagKey := strings.Split(columnName, ":")[1]
+	tagKey := columnName[4:]
 	for _, t := range tags {
 		if *t.Key == tagKey {
 			return *t.Value


### PR DESCRIPTION
If tag-key has multiple colon, the column value was empty.
Because use 'Split' and only picked 2nd element. 
```
Tag:Name => Name
```
But element is more.
```
Tag:aws:autoscaling:groupName => aws (expected: aws:autoscaling:groupName)
```

Stopped to use 'Split'.